### PR TITLE
Update allow-ip.sh

### DIFF
--- a/allow-ip.sh
+++ b/allow-ip.sh
@@ -19,7 +19,7 @@ if [ $1 = "nginx" ]; then
         if [ $2 = "-r" ]; then
                 for IP in "${@:3}"
                 do
-                        sed -i '/$IP/d' ./nginx/conf.d/whitelist
+                        sed -i '/'$IP'/d' ./nginx/conf.d/whitelist
                 done
         else
                 for IP in "${@:2}"


### PR DESCRIPTION
sed is allways retrieving "$IP" instead of the actual $IP argument resulting in the non-deletion of the IP entry when using the flag -r.